### PR TITLE
Fix album detail navigation with basename

### DIFF
--- a/web/ui/src/components/views/AlbumsView.tsx
+++ b/web/ui/src/components/views/AlbumsView.tsx
@@ -308,18 +308,18 @@ const AlbumsView: React.FC = () => {
               <p className="text-sm text-cyber-secondary truncate">{album.artist}</p>
               <p className="text-xs text-cyber-muted truncate">{album.genre || '未分类'}</p>
               
-              <div className="mt-4 flex justify-between items-center">
-                <button
-                  onClick={() => window.location.href = `/album/${album.id}`}
-                  className="flex items-center px-3 py-1 rounded-full text-sm font-medium bg-[#2563eb] text-white hover:bg-[#1d4ed8] transition-colors"
-                >
+                <div className="mt-4 flex justify-between items-center">
+                  <button
+                    onClick={() => navigate(`/album/${album.id}`)}
+                    className="flex items-center px-3 py-1 rounded-full text-sm font-medium bg-[#2563eb] text-white hover:bg-[#1d4ed8] transition-colors"
+                  >
                   <Music2 className="mr-1 h-4 w-4" /> 查看详情
                 </button>
                 <div className="flex space-x-2">
-                  <button
-                    onClick={() => window.location.href = `/album/${album.id}/edit`}
-                    className="p-1 rounded-full text-[#2563eb] hover:text-[#1d4ed8] transition-colors"
-                  >
+                    <button
+                      onClick={() => navigate(`/album/${album.id}/edit`)}
+                      className="p-1 rounded-full text-[#2563eb] hover:text-[#1d4ed8] transition-colors"
+                    >
                     <Edit2 className="h-5 w-5" />
                   </button>
                   <button


### PR DESCRIPTION
## Summary
- use `navigate` instead of `window.location.href` when jumping to album pages

## Testing
- `go build ./...`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_b_68451105a67483298eaec99698abd61c