### PR TITLE
Fix backend URL duplication

### DIFF
--- a/web/ui/src/components/views/BotView.tsx
+++ b/web/ui/src/components/views/BotView.tsx
@@ -27,12 +27,23 @@ interface NeteaseSong {
 // 声明全局变量类型
 declare const __BACKEND_URL__: string;
 
-// 获取后端 URL，提供默认值
+// 获取后端 URL，提供默认值并确保是绝对地址
 const getBackendUrl = () => {
+  let url: string;
+
   if (typeof __BACKEND_URL__ !== 'undefined') {
-    return __BACKEND_URL__;
+    url = __BACKEND_URL__;
+  } else {
+    url = import.meta.env.VITE_BACKEND_URL || 'http://localhost:8080';
   }
-  return import.meta.env.VITE_BACKEND_URL || 'http://localhost:8080';
+
+  // 如果没有协议，使用当前页面的协议补全
+  if (!/^https?:\/\//.test(url)) {
+    const { protocol } = window.location;
+    url = `${protocol}//${url}`;
+  }
+
+  return url;
 };
 
 const BotView: React.FC = () => {

--- a/web/ui/src/contexts/PlayerContext.tsx
+++ b/web/ui/src/contexts/PlayerContext.tsx
@@ -55,12 +55,22 @@ const PlayerContext = createContext<PlayerContextType | undefined>(undefined);
 // 声明全局变量类型
 declare const __BACKEND_URL__: string;
 
-// 获取后端 URL，提供默认值
+// 获取后端 URL，提供默认值并确保是绝对地址
 const getBackendUrl = () => {
+  let url: string;
+
   if (typeof __BACKEND_URL__ !== 'undefined') {
-    return __BACKEND_URL__;
+    url = __BACKEND_URL__;
+  } else {
+    url = import.meta.env.VITE_BACKEND_URL || 'http://localhost:8080';
   }
-  return import.meta.env.VITE_BACKEND_URL || 'http://localhost:8080';
+
+  if (!/^https?:\/\//.test(url)) {
+    const { protocol } = window.location;
+    url = `${protocol}//${url}`;
+  }
+
+  return url;
 };
 
 export const PlayerProvider: React.FC<{ children: ReactNode }> = ({ children }) => {


### PR DESCRIPTION
## Summary
- handle missing scheme in `getBackendUrl`

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: TS errors)*
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_b_6845152af4e08329b133b52bfe826508