### PR TITLE
Implement runtime configuration via env-config.js

### DIFF
--- a/web/ui/index.html
+++ b/web/ui/index.html
@@ -8,6 +8,8 @@
   </head>
   <body>
     <div id="root"></div>
+    <script src="/config/env-config.js"></script>
+    <script src="/config/poll-config.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
-</html> 
+</html>

--- a/web/ui/public/config/env-config.js
+++ b/web/ui/public/config/env-config.js
@@ -1,0 +1,3 @@
+window.__ENV__ = {
+  BACKEND_URL: 'http://localhost:8080'
+};

--- a/web/ui/public/config/poll-config.js
+++ b/web/ui/public/config/poll-config.js
@@ -1,0 +1,18 @@
+(function(){
+  let currentText = '';
+  async function check(){
+    try {
+      const res = await fetch('/config/env-config.js?cache=' + Date.now());
+      const text = await res.text();
+      if(!currentText){
+        currentText = text;
+      } else if(text !== currentText){
+        location.reload();
+      }
+    } catch(e){
+      console.error('Failed to fetch env config', e);
+    }
+  }
+  check();
+  setInterval(check, 30000);
+})();

--- a/web/ui/src/components/views/BotView.tsx
+++ b/web/ui/src/components/views/BotView.tsx
@@ -24,13 +24,10 @@ interface NeteaseSong {
   coverUrl?: string; // 添加静态封面URL字段
 }
 
-// 声明全局变量类型
-declare const __BACKEND_URL__: string;
-
 // 获取后端 URL，提供默认值
 const getBackendUrl = () => {
-  if (typeof __BACKEND_URL__ !== 'undefined') {
-    return __BACKEND_URL__;
+  if (typeof window !== 'undefined' && (window as any).__ENV__?.BACKEND_URL) {
+    return (window as any).__ENV__.BACKEND_URL;
   }
   return import.meta.env.VITE_BACKEND_URL || 'http://localhost:8080';
 };
@@ -66,7 +63,7 @@ const BotView: React.FC = () => {
   useEffect(() => {
     console.log('🔧 BotView 后端URL配置信息:');
     console.log('  - VITE_BACKEND_URL 环境变量:', import.meta.env.VITE_BACKEND_URL);
-    console.log('  - __BACKEND_URL__ 全局变量:', typeof __BACKEND_URL__ !== 'undefined' ? __BACKEND_URL__ : 'undefined');
+    console.log('  - window.__ENV__ 全局变量:', (window as any).__ENV__);
     console.log('  - 最终使用的后端URL:', backendUrl);
     console.log('  - 当前页面URL:', window.location.href);
   }, [backendUrl]);

--- a/web/ui/src/contexts/PlayerContext.tsx
+++ b/web/ui/src/contexts/PlayerContext.tsx
@@ -52,13 +52,11 @@ interface PlayerContextType {
 
 const PlayerContext = createContext<PlayerContextType | undefined>(undefined);
 
-// 声明全局变量类型
-declare const __BACKEND_URL__: string;
-
 // 获取后端 URL，提供默认值
 const getBackendUrl = () => {
-  if (typeof __BACKEND_URL__ !== 'undefined') {
-    return __BACKEND_URL__;
+  // 从全局变量读取
+  if (typeof window !== 'undefined' && (window as any).__ENV__?.BACKEND_URL) {
+    return (window as any).__ENV__.BACKEND_URL;
   }
   return import.meta.env.VITE_BACKEND_URL || 'http://localhost:8080';
 };

--- a/web/ui/src/types/env.d.ts
+++ b/web/ui/src/types/env.d.ts
@@ -1,0 +1,11 @@
+export interface RuntimeEnv {
+  BACKEND_URL: string;
+}
+
+declare global {
+  interface Window {
+    __ENV__?: RuntimeEnv;
+  }
+}
+
+export {};

--- a/web/ui/vite.config.ts
+++ b/web/ui/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig(({ mode }) => {
     base: '/1qfm/',
     plugins: [react()],
     define: {
-      __BACKEND_URL__: JSON.stringify(env.VITE_BACKEND_URL || 'http://localhost:8080')
+      __BACKEND_URL__: `window.__ENV__?.BACKEND_URL || '${env.VITE_BACKEND_URL || 'http://localhost:8080'}'`
     },
     build: {
       rollupOptions: {

--- a/web/ui/vite.config.ts
+++ b/web/ui/vite.config.ts
@@ -10,7 +10,10 @@ export default defineConfig(({ mode }) => {
     base: '/1qfm/',
     plugins: [react()],
     define: {
-      __BACKEND_URL__: `window.__ENV__?.BACKEND_URL || '${env.VITE_BACKEND_URL || 'http://localhost:8080'}'`
+      // Provide a default backend URL at build time. The actual URL can be
+      // overridden at runtime via the `window.__ENV__` object defined in
+      // `public/config/env-config.js`.
+      __BACKEND_URL__: JSON.stringify(env.VITE_BACKEND_URL || 'http://localhost:8080')
     },
     build: {
       rollupOptions: {


### PR DESCRIPTION
## Summary
- load backend URL from `window.__ENV__` at runtime
- ignore `.env.production` usage and use fallback when global config missing
- include env-config and polling scripts
- expose type definitions for runtime config

## Testing
- `npm run build` *(fails: TS errors in repo)*

------
https://chatgpt.com/codex/tasks/task_b_684521ddd1648329b3763c96d115216d